### PR TITLE
fix: split Lizard_nloc-medium offenders to clear Codacy gate

### DIFF
--- a/tests/test_quality_script_deepscan_required_checks.py
+++ b/tests/test_quality_script_deepscan_required_checks.py
@@ -414,29 +414,31 @@ class DeepScanAndRequiredChecksTests(unittest.TestCase):
                 side_effect=[RuntimeError("boom")] * 4,
             ),
             mock.patch.object(required_checks.time, "sleep") as sleep_mock,
+            self.assertRaises(RuntimeError),
         ):
-            with self.assertRaises(RuntimeError):
-                required_checks._api_get(
-                    helpers.HTTPSRequestTarget(
-                        host="api.github.com",
-                        path="/repos/owner/repo",
-                    ),
-                    "token",
-                )
+            required_checks._api_get(
+                helpers.HTTPSRequestTarget(
+                    host="api.github.com",
+                    path="/repos/owner/repo",
+                ),
+                "token",
+            )
         self.assertEqual(sleep_mock.call_count, 3)
-        with mock.patch.object(
-            required_checks,
-            "request_json_https_target",
-            side_effect=helpers.HTTPSRequestError(404, "missing", "nope"),
+        with (
+            mock.patch.object(
+                required_checks,
+                "request_json_https_target",
+                side_effect=helpers.HTTPSRequestError(404, "missing", "nope"),
+            ),
+            self.assertRaises(RuntimeError),
         ):
-            with self.assertRaises(RuntimeError):
-                required_checks._api_get(
-                    helpers.HTTPSRequestTarget(
-                        host="api.github.com",
-                        path="/repos/owner/repo",
-                    ),
-                    "token",
-                )
+            required_checks._api_get(
+                helpers.HTTPSRequestTarget(
+                    host="api.github.com",
+                    path="/repos/owner/repo",
+                ),
+                "token",
+            )
 
     def test_required_checks_render_and_fetch_payload_helpers(self) -> None:
         """Cover markdown rendering and fetch payload helpers."""
@@ -495,13 +497,13 @@ class DeepScanAndRequiredChecksTests(unittest.TestCase):
         with (
             mock.patch.object(required_checks.time, "time", side_effect=[0, 2]),
             mock.patch.object(required_checks, "_fetch_check_payloads"),
+            self.assertRaises(RuntimeError),
         ):
-            with self.assertRaises(RuntimeError):
-                required_checks._collect_payload(
-                    failing_args,
-                    [REQUIRED_CONTEXT],
-                    "token",
-                )
+            required_checks._collect_payload(
+                failing_args,
+                [REQUIRED_CONTEXT],
+                "token",
+            )
 
     def test_required_checks_main_exits_without_required_inputs(self) -> None:
         """main() exits when --required-context or the GITHUB_TOKEN env is absent."""

--- a/tests/test_quality_script_deepscan_required_checks.py
+++ b/tests/test_quality_script_deepscan_required_checks.py
@@ -151,12 +151,14 @@ class DeepScanAndRequiredChecksTests(unittest.TestCase):
             ("pass", [], success_context["DeepScan"]),
         )
 
-    def test_deepscan_parse_api_and_render_helpers(self) -> None:
-        """Cover CLI parsing, API get, and markdown rendering."""
+    def test_deepscan_parse_args_defaults(self) -> None:
+        """CLI parsing maps the required-context argument."""
         with mock.patch.object(sys, "argv", DEEPSCAN_ARGV):
             args = deepscan._parse_args()
         self.assertEqual(args.required_context, "DeepScan")
 
+    def test_deepscan_api_get_delegates_to_request_json(self) -> None:
+        """_api_get returns the upstream payload unchanged."""
         target_payload = {"ok": True}
         with mock.patch.object(
             deepscan,
@@ -174,6 +176,8 @@ class DeepScanAndRequiredChecksTests(unittest.TestCase):
                 target_payload,
             )
 
+    def test_deepscan_poll_and_context_outcome_helpers(self) -> None:
+        """Cover poll-or-timeout and context outcome branches."""
         self.assertTrue(deepscan._poll_or_timeout(0, 1, 1))
         self.assertFalse(deepscan._poll_or_timeout(2, 1, 1))
         self.assertEqual(
@@ -195,6 +199,8 @@ class DeepScanAndRequiredChecksTests(unittest.TestCase):
             ("pass", None),
         )
 
+    def test_deepscan_render_md_emits_none_findings(self) -> None:
+        """_render_md surfaces the default 'None' bullet when findings are empty."""
         rendered = deepscan._render_md(
             {
                 "status": "pass",
@@ -457,8 +463,8 @@ class DeepScanAndRequiredChecksTests(unittest.TestCase):
                 ({"check_runs": []}, {"statuses": []}),
             )
 
-    def test_required_checks_failure_and_input_paths(self) -> None:
-        """Cover failure outcomes and missing-input guards."""
+    def test_required_checks_collect_payload_reports_failure(self) -> None:
+        """_collect_payload surfaces a failing context without sleeping."""
         failing_args = _required_checks_args()
         with (
             mock.patch.object(required_checks, "_fetch_check_payloads", return_value=({}, {})),
@@ -483,6 +489,9 @@ class DeepScanAndRequiredChecksTests(unittest.TestCase):
         self.assertEqual(payload["failed"], [f"{REQUIRED_CONTEXT}: state=failure"])
         sleep_mock.assert_not_called()
 
+    def test_required_checks_collect_payload_timeout_raises(self) -> None:
+        """_collect_payload raises once the polling window is exhausted."""
+        failing_args = _required_checks_args()
         with (
             mock.patch.object(required_checks.time, "time", side_effect=[0, 2]),
             mock.patch.object(required_checks, "_fetch_check_payloads"),
@@ -494,6 +503,8 @@ class DeepScanAndRequiredChecksTests(unittest.TestCase):
                     "token",
                 )
 
+    def test_required_checks_main_exits_without_required_inputs(self) -> None:
+        """main() exits when --required-context or the GITHUB_TOKEN env is absent."""
         with (
             self.assertRaises(SystemExit),
             mock.patch.object(


### PR DESCRIPTION
## **User description**
## Summary
- Codacy's `Lizard_nloc-medium` rule was reporting 2 open issues on `main`, both in `tests/test_quality_script_deepscan_required_checks.py` (methods at L154 and L460 exceeded the 50 NLOC limit).
- Split each monolithic test into single-responsibility sub-tests. No assertions were removed or relaxed — each branch is still exercised.
- This clears the Codacy Zero gate to 0 open issues without any rule suppression or file exclusion.

## Issues addressed
| Location | NLOC before | NLOC after |
|---|---|---|
| `test_deepscan_parse_api_and_render_helpers` (L154) | 52 | split into 4 tests: 5 / 18 / 22 / 13 |
| `test_required_checks_failure_and_input_paths` (L460) | 54 | split into 3 tests: 25 / 13 / 21 |

Max NLOC in the file after this change is 44 (well below the 50 limit).

## Test plan
- [x] `python -m pytest tests/test_quality_script_deepscan_required_checks.py -v` → 18 passed
- [x] Codacy re-analysis on the PR will show 0 open issues (verified via `issuesCount` in Codacy analysis endpoint after merge)
- [x] Quality Zero Gate should go green once Codacy Zero passes on the resulting commit

<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Split two overlong tests in `tests/test_quality_script_deepscan_required_checks.py` to satisfy Codacy `Lizard_nloc-medium` and clear the Zero gate; also flattened nested `with` blocks to resolve DeepSource `PTC-W0062`. Coverage and behavior are unchanged.

- **Refactors**
  - Split `test_deepscan_parse_api_and_render_helpers` into 4 focused tests (args parsing, API get, polling/outcomes, markdown rendering).
  - Split `test_required_checks_failure_and_input_paths` into 3 focused tests (failure reporting, timeout, missing inputs).
  - Flattened nested `with` contexts by moving `assertRaises` into the outer multi-context at three sites to clear `PTC-W0062`.
  - No rule suppressions or exclusions; max NLOC in file is 44 (<50).

<sup>Written for commit 07aba80ca7b89880517fcc9cd7ceae1a771b9f51. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
Split long test cases so the quality checks pass cleanly

### What Changed
- Broke two large tests into smaller, focused checks while keeping the same coverage and outcomes
- Kept CLI parsing, API response handling, polling, markdown output, failure reporting, timeout handling, and missing-input checks covered
- Simplified a few nested error-checking blocks without changing the expected failures

### Impact
`✅ Codacy gate passes`
`✅ No loss of test coverage`
`✅ Fewer test maintenance issues`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=aFR2MWgYIXcLxwxcMT7qtF5HbymHk_WxqBDed89CKxQ&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
