### PR TITLE
fix: clear DeepSource: Python blocking findings on main

### DIFF
--- a/scripts/quality/check_sonar_zero.py
+++ b/scripts/quality/check_sonar_zero.py
@@ -201,6 +201,28 @@ def _evaluate_findings(
     return findings
 
 
+def _wait_for_pr_sha(
+    args: argparse.Namespace, auth: str, project_key: str
+) -> Optional[List[str]]:
+    """Block until Sonar indexes the expected PR head SHA, or return findings on timeout."""
+    expected_pr_sha = args.expected_pr_sha.strip()
+    if not (args.pull_request and expected_pr_sha):
+        return None
+    deadline = time.time() + max(args.max_wait_seconds, 0)
+    observed_sha = ""
+    while True:
+        observed_sha = _fetch_pr_analysis_sha(auth, project_key, args.pull_request)
+        if observed_sha == expected_pr_sha:
+            return None
+        if time.time() >= deadline:
+            return [
+                "Sonar PR analysis did not reach the expected head SHA before timeout.",
+                f"Expected SHA: {expected_pr_sha}",
+                f"Observed SHA: {observed_sha or 'missing'}",
+            ]
+        time.sleep(max(args.poll_interval_seconds, 1))
+
+
 def _run_sonar_check(args: argparse.Namespace, token: str) -> SonarResult:
     """Run the Sonar gate check and return the computed result tuple."""
     if not token:
@@ -208,33 +230,9 @@ def _run_sonar_check(args: argparse.Namespace, token: str) -> SonarResult:
 
     auth = _auth_header(token)
     project_key = require_slug(args.project_key, label="Sonar project key")
-    expected_pr_sha = args.expected_pr_sha.strip()
-    if (
-        args.pull_request and expected_pr_sha
-    ):  # pragma: no branch - external PR analysis gate
-        deadline = time.time() + max(args.max_wait_seconds, 0)
-        observed_sha = ""
-        while True:
-            observed_sha = _fetch_pr_analysis_sha(auth, project_key, args.pull_request)
-            if observed_sha == expected_pr_sha:
-                break
-            if time.time() >= deadline:
-                timeout_message = (
-                    "Sonar PR analysis did not reach the expected head SHA before "
-                    "timeout."
-                )
-                return (
-                    "fail",
-                    None,
-                    None,
-                    None,
-                    [
-                        timeout_message,
-                        f"Expected SHA: {expected_pr_sha}",
-                        f"Observed SHA: {observed_sha or 'missing'}",
-                    ],
-                )
-            time.sleep(max(args.poll_interval_seconds, 1))
+    timeout_findings = _wait_for_pr_sha(args, auth, project_key)
+    if timeout_findings is not None:
+        return "fail", None, None, None, timeout_findings
 
     issues_query, gate_query, hotspots_query = _build_queries(args, project_key)
     open_issues = _fetch_open_issues(auth, issues_query)

--- a/scripts/quality/check_sonar_zero.py
+++ b/scripts/quality/check_sonar_zero.py
@@ -204,7 +204,7 @@ def _evaluate_findings(
 def _wait_for_pr_sha(
     args: argparse.Namespace, auth: str, project_key: str
 ) -> Optional[List[str]]:
-    """Block until Sonar indexes the expected PR head SHA, or return findings on timeout."""
+    """Wait for the expected PR head SHA, returning findings if the deadline lapses."""
     expected_pr_sha = args.expected_pr_sha.strip()
     if not (args.pull_request and expected_pr_sha):
         return None

--- a/scripts/quality/lcov_path_support.py
+++ b/scripts/quality/lcov_path_support.py
@@ -108,7 +108,7 @@ def normalize_source_path(
     if candidate == repo_root:
         return ""
     if candidate.startswith(repo_root + "/"):
-        candidate = candidate[len(repo_root) + 1 :]
+        candidate = candidate[len(repo_root) + 1:]
 
     matched = matching_repo_suffix(candidate, repo_indexes.casefold_paths)
     if matched.casefold() in repo_indexes.casefold_paths:

--- a/scripts/security_helpers.py
+++ b/scripts/security_helpers.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Any, Dict, Optional, Set, Tuple
 from urllib.parse import urlparse, urlunparse
 
+from scripts import security_http_support, security_validation_support
 from scripts import security_shared as _security_shared
 from scripts.security_shared import (
     HTTPSHost,
@@ -22,16 +23,12 @@ HTTPSResponsePayload = _security_shared.HTTPSResponsePayload
 
 
 def _validation_module():
-    """Import the validation support module lazily to avoid circular imports."""
-    from scripts import security_validation_support
-
+    """Return the validation support module for backward-compatible lookups."""
     return security_validation_support
 
 
 def _http_module():
-    """Import the HTTP support module lazily to avoid circular imports."""
-    from scripts import security_http_support
-
+    """Return the HTTP support module for backward-compatible lookups."""
     return security_http_support
 
 

--- a/scripts/security_validation_support.py
+++ b/scripts/security_validation_support.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import, annotations, division
 
 import ipaddress
 from pathlib import Path
-from typing import Any, FrozenSet, List, Optional, Set, Tuple
+from typing import Any, List, Optional, Set, Tuple
 from urllib.parse import quote, urlparse, urlunparse
 
 from scripts.security_shared import (

--- a/tests/test_quality_script_sonar.py
+++ b/tests/test_quality_script_sonar.py
@@ -107,6 +107,17 @@ class SonarScriptTests(unittest.TestCase):
         self.assertTrue(sonar._auth_header("token").startswith("Basic "))
         self.assertEqual(sonar._paged_total({"paging": {"total": 5}}), 5)
 
+        non_pr_args = _sonar_args(pull_request="", expected_pr_sha="")
+        self.assertIsNone(sonar._wait_for_pr_sha(non_pr_args, "auth", "project"))
+        with ExitStack() as stack:
+            stack.enter_context(mock.patch.object(sonar, "_fetch_open_issues", return_value=0))
+            stack.enter_context(mock.patch.object(sonar, "_fetch_unresolved_hotspots", return_value=0))
+            stack.enter_context(mock.patch.object(sonar, "_fetch_quality_gate", return_value="OK"))
+            self.assertEqual(
+                sonar._run_sonar_check(non_pr_args, "token")[0],
+                "pass",
+            )
+
         args = _sonar_args(expected_pr_sha="want", max_wait_seconds=0)
         with ExitStack() as stack:
             stack.enter_context(


### PR DESCRIPTION
## **User description**
## Summary
Main's `DeepSource: Python` status has been failing silently for a long time. It was not marked as a required-status-check blocker when the `DeepSource Visible Zero` wrapper passed, but it is a real signal — DeepSource's Python analyzer was surfacing five blocking pylint-family rules in `scripts/`.

This PR resolves all five at the source with no suppressions.

## Issues addressed
| File:line | Rule | Fix |
|---|---|---|
| `scripts/security_validation_support.py:7` | pylint `unused-import` (FrozenSet) | dropped from the typing import tuple |
| `scripts/security_helpers.py:26,33` | pylint `import-outside-toplevel` x2 | hoisted `security_validation_support` and `security_http_support` to the module top; the lazy imports had no real circular dep after earlier refactors |
| `scripts/quality/check_sonar_zero.py:204` | pylint `too-many-locals (16/15)` | extracted `_wait_for_pr_sha` helper so `_run_sonar_check` drops below the 15-locals ceiling |
| `scripts/quality/lcov_path_support.py:111` | pycodestyle `E203` (whitespace before `:`) | tightened the slice expression |

## Test plan
- [x] `python -m pytest tests/test_quality_script_sonar.py tests/test_quality_script_deepscan_required_checks.py tests/test_quality_coverage_scripts.py tests/test_quality_script_paths.py` → 43 passed
- [x] `python -m prospector --strictness high` at repo root → 0 messages
- [ ] `DeepSource: Python` status flips from failure → success on the resulting commit
- [ ] `DeepSource Visible Zero` stays green

<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixes the failing `DeepSource: Python` status on `main` by resolving five blocking lints in `scripts/` with no suppressions. Restores a reliable CI signal, adds tests for the non-PR Sonar path, and trims a docstring to meet DeepSource’s line-length rule.

- **Bug Fixes**
  - Dropped unused `FrozenSet` import in `scripts/security_validation_support.py`.
  - Moved `security_validation_support` and `security_http_support` imports to the top of `scripts/security_helpers.py`.
  - Extracted `_wait_for_pr_sha` in `scripts/quality/check_sonar_zero.py` to reduce locals and simplify timeout handling.
  - Fixed E203 whitespace in `scripts/quality/lcov_path_support.py` slice expression.
  - Added tests for `_wait_for_pr_sha` non-PR path and non-PR `_run_sonar_check`.
  - Shortened `_wait_for_pr_sha` docstring to satisfy DeepSource’s 88-char limit.

<sup>Written for commit 3a275ea136ec0a7201e22f18c7d84eee30973647. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Fix DeepSource Python failures on main and cover the Sonar non-PR path**

### What Changed
- Removed the remaining DeepSource blocking findings in `scripts/` so the Python status can pass again on main
- Sonar checks now handle runs that are not tied to a pull request without timing out or failing
- Added test coverage for the non-PR Sonar path and the refactored wait logic
- Cleaned up a path slice and removed an unused import to avoid style warnings

### Impact
`✅ Passing DeepSource Python checks on main`
`✅ Fewer Sonar check failures for non-PR runs`
`✅ Clearer test coverage for Sonar status checks`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=gUoAcv7VkFdiCYM9FRGlid6gk-_HR5fb5wE1AQWZomc&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
