### PR TITLE
fix: clear Sonar cpp:S6009 and cpp:S5566 findings on main

### DIFF
--- a/src/Booking.cpp
+++ b/src/Booking.cpp
@@ -121,7 +121,7 @@ std::string Booking::generateBookingId() const {
     return stream.str();
 }
 
-Booking::Booking(const std::string& custId, const std::string& flightNum, const std::string& seatNum)
+Booking::Booking(std::string_view custId, std::string_view flightNum, std::string_view seatNum)
     : customerId(custId) {
     applyFlightAndSeat(flightNum, seatNum);
 }

--- a/src/Booking.h
+++ b/src/Booking.h
@@ -31,7 +31,7 @@ private:
 
 public:
     // Constructor
-    Booking(const std::string& custId, const std::string& flightNum, const std::string& seatNum);
+    Booking(std::string_view custId, std::string_view flightNum, std::string_view seatNum);
 
     // Destructor
     ~Booking();

--- a/tests/auto_generated_customer_test_helpers.h
+++ b/tests/auto_generated_customer_test_helpers.h
@@ -1,6 +1,7 @@
 #ifndef AUTO_GENERATED_CUSTOMER_TEST_HELPERS_H
 #define AUTO_GENERATED_CUSTOMER_TEST_HELPERS_H
 
+#include <algorithm>
 #include <array>
 #include <string_view>
 
@@ -12,12 +13,9 @@ inline bool has_expected_auto_generated_customer_name(const std::string_view nam
         "SystemPerson_",
         "BackendBot_",
     };
-    for (const auto& prefix : prefixes) {
-        if (name.starts_with(prefix)) {
-            return true;
-        }
-    }
-    return false;
+    return std::ranges::any_of(prefixes, [name](std::string_view prefix) {
+        return name.starts_with(prefix);
+    });
 }
 
 #endif


### PR DESCRIPTION
## **User description**
## Summary
Sonar's fresh analysis of main surfaced 10 C++ findings after SonarCloud refreshed its rule set. 6 of them are already resolved by PR #44's constructor pattern but haven't been re-analyzed yet. This PR tackles the remaining 4:

| Rule | Where | Fix |
|---|---|---|
| `cpp:S6009` x3 | `src/Booking.cpp:124` | `Booking::Booking` parameters changed from `const std::string&` to `std::string_view`. Header signature updated to match. All call sites pass string literals or `std::string` — both implicitly convert. |
| `cpp:S5566` x1 | `tests/auto_generated_customer_test_helpers.h:15` | Ranged for-loop over prefixes swapped for `std::ranges::any_of`. |

## Test plan
- [x] C++ compiles (uses `std::string_view` constructor of `std::string` — C++17).
- [ ] Sonar main open-issue count drops from 10 → 0 once both this PR and the already-merged PR #44 are analyzed.
- [ ] Codacy main remains 0 issues.
- [ ] DeepSource: Python remains success.

<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Switches `Booking` constructor params to `std::string_view` and replaces a test loop with `std::ranges::any_of` to clear Sonar cpp:S6009 and cpp:S5566 findings. No call site changes; string literals and `std::string` still work.

- **Bug Fixes**
  - Updated `Booking::Booking` signature (header and impl) from `const std::string&` to `std::string_view` to satisfy cpp:S6009.
  - In tests, replaced the prefix loop with `std::ranges::any_of` and included `<algorithm>` to satisfy cpp:S5566.

<sup>Written for commit 194d2f873e1adae815e35d800bdb02804d7acc55. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Accept booking details from string-like values and keep customer-name checks working**

### What Changed
- Booking creation now accepts string-like values directly for customer, flight, and seat fields, so existing calls with text literals and strings continue to work.
- The customer test helper now checks the allowed name prefixes with the same result as before, using a simpler prefix match.

### Impact
`✅ Fewer Sonar warnings on main`
`✅ Booking creation still accepts text literals and strings`
`✅ Cleaner customer-name validation in tests`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=Tf3eDtVpwGaOejhYAOOgSMMJTwS5TTw0XUi_E8c1Pgc&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
