### PR TITLE
fix: move Seat constants to in-class initializers for Sonar S3230

### DIFF
--- a/src/Seat.cpp
+++ b/src/Seat.cpp
@@ -14,8 +14,7 @@ std::string seatClassToString(SeatClass sc) {
 }
 
 // Constructor
-Seat::Seat(std::string_view id, SeatClass sc, double basePrice)
-    : isBooked(false) {
+Seat::Seat(std::string_view id, SeatClass sc, double basePrice) {
     applyIdentityAndPrice(id, sc, basePrice);
 }
 

--- a/src/Seat.h
+++ b/src/Seat.h
@@ -18,9 +18,9 @@ enum class SeatClass {
 class Seat {
 private:
     std::string seatId;     // e.g., "1A", "12F"
-    bool isBooked;
-    double price;
-    SeatClass seatClass;
+    bool isBooked = false;
+    double price = 0.0;
+    SeatClass seatClass = SeatClass::ECONOMY;
 
     void applyIdentityAndPrice(std::string_view id, SeatClass sc, double basePrice); // Populate state after partial init
 


### PR DESCRIPTION
## **User description**
## Summary
Sonar's `cpp:S3230` variant \"Use the in-class initializer instead\" fires on `src/Seat.cpp:18` (`: isBooked(false)`) because the value is a constant. This PR moves `isBooked`, `price`, and `seatClass` default initializers into the header so the constructor doesn't need to initialize them directly.

Behavior is unchanged: the Seat constructor now delegates entirely to `applyIdentityAndPrice`, which still overwrites `seatId` / `price` / `seatClass` from the arguments. `isBooked` remains `false` by default.

Booking's `: customerId(custId)` stays — its initializer depends on a constructor parameter, not a constant, so S3230 doesn't apply.

## Expected
- Sonar main open_issues drops from 2 → 0 after Sonar re-analyzes this commit plus PR #45's fix.

<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Move `Seat` constant defaults to in-class initializers to satisfy Sonar `cpp:S3230` and simplify the constructor. Behavior is unchanged; the constructor delegates to `applyIdentityAndPrice`, and `isBooked` stays `false` by default.

**Refactors**
- In `Seat.h`, add defaults: `bool isBooked = false;`, `double price = 0.0;`, `SeatClass seatClass = SeatClass::ECONOMY;`
- Remove `: isBooked(false)` from the `Seat` constructor
- Keep `Booking`’s `: customerId(custId)` (parameter-dependent; S3230 not applicable)
- Expect Sonar open issues to drop to 0 after re-analysis

<sup>Written for commit 00bfc4cc5a758aa9d414db6ff0e1d17e78964681. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Keep seat defaults in one place**

### What Changed
- Seat now stores its default booked state, price, and class directly with the data itself
- The constructor no longer sets the booked state separately, while seat ID, price, and class still come from the provided values
- Seat behavior stays the same for users: new seats still start unbooked with the same default price and economy class

### Impact
`✅ Fewer seat default mismatches`
`✅ Consistent new-seat values`
`✅ Cleaner seat setup`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=5mth4l2-g4dB1A2_TvmxxVDNNfAy5oEOgDLRL4Hbe8s&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
