### PR TITLE
fix: restructure auto-customer pools to clear CodeQL cpp/missing-return

### DIFF
--- a/src/ReservationSystemHelpers.cpp
+++ b/src/ReservationSystemHelpers.cpp
@@ -2,7 +2,6 @@
 #include "ReservationSystemHelpers.h"
 #include <array>
 #include <format>
-#include <span>
 #include <string_view>
 
 namespace reservation_system_helpers {
@@ -61,10 +60,12 @@ std::string readNonEmptyLine(std::istream& in, std::ostream& out, const std::str
 }
 
 namespace {
+using AutoFirstNamePool = std::array<std::string_view, 5>;
+
 AutoCustomerData generateAutoCustomerDataFromPool(
     const std::string& newId,
     SeedValue seedConstant,
-    std::span<const std::string_view> firstNames
+    const AutoFirstNamePool& firstNames
 ) {
     const SeedValue seed = buildDeterministicSeed(newId, seedConstant);
     const std::string name = buildDeterministicAutoName(
@@ -77,26 +78,30 @@ AutoCustomerData generateAutoCustomerDataFromPool(
 }
 } // namespace
 
+namespace {
+constexpr AutoFirstNamePool kDefaultFirstNames = {
+    "AutoPat",
+    "RoboUser",
+    "GenClient",
+    "SysPerson",
+    "BotPassenger",
+};
+
+constexpr AutoFirstNamePool kApiFirstNames = {
+    "ApiPat",
+    "WebServiceUser",
+    "JsonGenClient",
+    "SystemPerson",
+    "BackendBot",
+};
+} // namespace
+
 AutoCustomerData generateAutoCustomerData(const std::string& newId) {
-    static constexpr std::array<std::string_view, 5> firstNames = {
-        "AutoPat",
-        "RoboUser",
-        "GenClient",
-        "SysPerson",
-        "BotPassenger",
-    };
-    return generateAutoCustomerDataFromPool(newId, 0x9E3779B97F4A7C15ULL, firstNames);
+    return generateAutoCustomerDataFromPool(newId, 0x9E3779B97F4A7C15ULL, kDefaultFirstNames);
 }
 
 AutoCustomerData generateApiAutoCustomerData(const std::string& newId) {
-    static constexpr std::array<std::string_view, 5> firstNames = {
-        "ApiPat",
-        "WebServiceUser",
-        "JsonGenClient",
-        "SystemPerson",
-        "BackendBot",
-    };
-    return generateAutoCustomerDataFromPool(newId, 0xD1B54A32D192ED03ULL, firstNames);
+    return generateAutoCustomerDataFromPool(newId, 0xD1B54A32D192ED03ULL, kApiFirstNames);
 }
 
 std::string formatCustomerId(int counter) {


### PR DESCRIPTION
## **User description**
## Summary
CodeQL's `cpp/missing-return` reported on `src/ReservationSystemHelpers.cpp:81` and `:92` for `generateAutoCustomerData` / `generateApiAutoCustomerData`. CodeQL's parser appears to mis-anchor a `static constexpr std::array` declaration at function end and lose the trailing `return`.

Fix by hoisting the two first-name pools to file-scope `constexpr AutoFirstNamePool` globals in the anonymous namespace. The public functions now have tiny one-statement bodies that forward to the `generateAutoCustomerDataFromPool` helper; CodeQL has no trouble seeing the return statement.

As a bonus, the helper now takes `const AutoFirstNamePool&` instead of `std::span`, so `<span>` is no longer included.

## Expected
- CodeQL cpp/missing-return count: 2 → 0.
- Behavior unchanged — same deterministic customer records generated.

<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Restructured auto-customer name pools to clear CodeQL `cpp/missing-return` by hoisting them to file-scope `constexpr` arrays and simplifying the two public generators. Behavior is unchanged; deterministic output remains the same.

- **Bug Fixes**
  - Moved first-name pools to anonymous-namespace `constexpr AutoFirstNamePool` (`kDefaultFirstNames`, `kApiFirstNames`).
  - Made `generateAutoCustomerData` and `generateApiAutoCustomerData` single-statement forwarders to `generateAutoCustomerDataFromPool`.
  - Updated helper to take `const AutoFirstNamePool&` instead of `std::span`; removed `<span>` include.
  - CodeQL `cpp/missing-return` in `ReservationSystemHelpers.cpp` reduced from 2 to 0.

<sup>Written for commit 19a4b268121d8ffdfec85e1d880f89969b38b28c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
Keep auto-generated customer records unchanged while fixing a CodeQL false positive

### What Changed
- Moved the default and API first-name pools out of the two generator functions and into shared file-level values
- Simplified both customer generators so they now pass those shared pools into a single helper
- Kept the generated customer names, ages, and money values the same
- Removed an unnecessary header include tied to the old pool handling

### Impact
`✅ CodeQL scan passes for customer generation`
`✅ No change to generated test customer data`
`✅ Simpler maintenance of auto-customer pools`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=ieQf_iuyJQj0EHPevs61rJZ4XLS7AuRht9A7Nqu58uw&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
