### PR TITLE
chore: clear 8 of 12 remaining CodeQL notes (switch → if, maybe_unused)

### DIFF
--- a/src/Booking.cpp
+++ b/src/Booking.cpp
@@ -101,13 +101,16 @@ std::uint64_t bookingSuffixToken(
 } // namespace
 
 std::string bookingStatusToString(BookingStatus status) {
-    using enum BookingStatus;
-    switch (status) {
-        case CONFIRMED: return "Confirmed";
-        case CANCELLED: return "Cancelled";
-        case PENDING: return "Pending";
-        default: return "Unknown";
+    if (status == BookingStatus::CONFIRMED) {
+        return "Confirmed";
     }
+    if (status == BookingStatus::CANCELLED) {
+        return "Cancelled";
+    }
+    if (status == BookingStatus::PENDING) {
+        return "Pending";
+    }
+    return "Unknown";
 }
 
 std::string Booking::generateBookingId() const {

--- a/src/Seat.cpp
+++ b/src/Seat.cpp
@@ -4,13 +4,13 @@
 
 // Helper function to convert SeatClass enum to string (can be outside class or static member)
 std::string seatClassToString(SeatClass sc) {
-    using enum SeatClass;
-
-    switch (sc) {
-        case ECONOMY: return "Economy";
-        case BUSINESS: return "Business";
-        default: return "Unknown";
+    if (sc == SeatClass::ECONOMY) {
+        return "Economy";
     }
+    if (sc == SeatClass::BUSINESS) {
+        return "Business";
+    }
+    return "Unknown";
 }
 
 // Constructor

--- a/tests/api_server_entry_and_helpers_cases.inc
+++ b/tests/api_server_entry_and_helpers_cases.inc
@@ -104,7 +104,7 @@ TEST(ApiServerHelpersTest, DetailBuildersReturnExpectedPayloads) {
     EXPECT_EQ(airplane_details.at("capacity"), flight->getCapacity());
     EXPECT_EQ(airplane_details.at("bookedSeatsCount"), flight->getBookedSeatsCount());
     EXPECT_EQ(airplane_details.at("isFull"), flight->isFull());
-    const auto seat_it = std::ranges::find_if(
+    [[maybe_unused]] const auto seat_it = std::ranges::find_if(
         airplane_details.at("seats"),
         [](const json& seat_details) { return seat_details.at("seatId") == "4A"; });
     ASSERT_NE(seat_it, airplane_details.at("seats").end());
@@ -163,9 +163,9 @@ TEST(ApiServerHelpersTest, DetailBuildersCoverLookupAndFilterBranches) {
 
     const Airplane* airplane = reservation_system.findAirplaneByFlightNumber("FL101");
     ASSERT_NE(airplane, nullptr);
-    const json airplane_details = build_airplane_details(reservation_system, *airplane);
+    [[maybe_unused]] const json airplane_details = build_airplane_details(reservation_system, *airplane);
     ASSERT_TRUE(airplane_details.contains("seats"));
-    const auto seat_it = std::ranges::find_if(
+    [[maybe_unused]] const auto seat_it = std::ranges::find_if(
         airplane_details.at("seats"),
         [](const json& seat_details) { return seat_details.at("seatId") == "4A"; });
     ASSERT_NE(seat_it, airplane_details.at("seats").end());
@@ -214,7 +214,7 @@ TEST(ApiServerEntryTest, MainReturnsSuccessWhenListenHookSucceeds) {
     ReservationSystem reservation_system(input, output_stream);
     httplib::Server server;
 
-    const int exit_code = run_api_server_with_listener(
+    [[maybe_unused]] const int exit_code = run_api_server_with_listener(
         reservation_system,
         server,
         output_stream,
@@ -324,7 +324,7 @@ TEST(ApiServerEntryTest, RunApiServerUsesDefaultListenWrapper) {
     server.stop();
 
     ASSERT_EQ(exit_code_future.wait_for(kStartupTimeout), std::future_status::ready);
-    const int exit_code = exit_code_future.get();
+    [[maybe_unused]] const int exit_code = exit_code_future.get();
     if (exit_code == 0) {
         EXPECT_TRUE(observed_healthy);
         EXPECT_NE(output_stream.str().find("Starting API server on http://localhost:8080"), std::string::npos);

--- a/tests/api_server_routes_cases.inc
+++ b/tests/api_server_routes_cases.inc
@@ -64,7 +64,7 @@ TEST_F(ApiServerRoutesTest, SupportsCustomerBookingLifecycleRoutes) {
     const auto cancel_response = client.Delete("/api/bookings/" + booking_id);
     expect_response_status(cancel_response, 200);
 
-    const auto options_response = client.Options("/api/bookings");
+    [[maybe_unused]] const auto options_response = client.Options("/api/bookings");
     expect_response_status(options_response, 204);
 }
 
@@ -164,14 +164,14 @@ TEST_F(ApiServerRoutesTest, SwapRoutesMapErrorsAndSuccess) {
     const auto same_booking_swap = swap_bookings_via_route(client, second_booking_id, second_booking_id);
     expect_response_status(same_booking_swap, 400);
 
-    const auto different_flights_swap = swap_bookings_via_route(client, second_booking_id, third_booking_id);
+    [[maybe_unused]] const auto different_flights_swap = swap_bookings_via_route(client, second_booking_id, third_booking_id);
     expect_response_status(different_flights_swap, 400);
 
     Booking* refreshed_first_booking = createBooking(first_customer->getPersonId(), "FL101", "5C");
     ASSERT_NE(refreshed_first_booking, nullptr);
     const std::string refreshed_first_booking_id = refreshed_first_booking->getBookingId();
 
-    const auto successful_swap = swap_bookings_via_route(client, refreshed_first_booking_id, second_booking_id);
+    [[maybe_unused]] const auto successful_swap = swap_bookings_via_route(client, refreshed_first_booking_id, second_booking_id);
     expect_response_status(successful_swap, 200);
     EXPECT_NE(
         json::parse(successful_swap->body).at("message").get<std::string>().find(


### PR DESCRIPTION
## **User description**
## Summary
Clears the low-hanging CodeQL note-severity alerts on main:

| Rule | Count | Fix |
|---|---|---|
| `cpp/trivial-switch` | 2 | `seatClassToString` and `bookingStatusToString` rewritten as if-else chains |
| `cpp/unused-static-variable` | 6 | six `const auto`/`const int` locals in `tests/*_cases.inc` get `[[maybe_unused]]` — all of them ARE used on the next line, but CodeQL loses track across TEST_F expansions |

Remaining after this PR: `cpp/include-non-header` (2, the `#define main; #include src.cpp; #undef main` test pattern), which requires larger structural changes (split main bodies into headers). Those stay as notes.

## Expected
- CodeQL alerts 12 → 4 after re-scan.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clear 8 of 12 low-severity CodeQL notes by rewriting two trivial switches and tagging six test locals with `[[maybe_unused]]`. Behavior is unchanged; CodeQL alerts should drop from 12 to 4 after re-scan.

- **Refactors**
  - Replace trivial switches with if-else chains in `bookingStatusToString` and `seatClassToString` to satisfy `cpp/trivial-switch`.
  - Add `[[maybe_unused]]` to six `const` locals in test `.inc` files to silence `cpp/unused-static-variable` false positives across `TEST_F` expansions.

<sup>Written for commit e881cd3b54e0b21f54e8ca8a5db6a2a24916af78. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Remove CodeQL false positives without changing booking behavior**

### What Changed
- Replaced two small switch-based label lookups with simple if/else checks; booking and seat labels still return the same text.
- Marked several test-only values as intentionally used so CodeQL stops flagging them in included test cases.
- Test behavior and API responses remain unchanged.

### Impact
`✅ Fewer CodeQL warnings on main`
`✅ Cleaner security and quality scans`
`✅ No change to booking or route results`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=VwAbwxgm9dBALBWG6bX-iU8mg9I0bnp9HsMK2dxPi1s&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
