### PR TITLE
fix: clear Sonar php:S103 and cpp:S6177 on main

### DIFF
--- a/src/Booking.cpp
+++ b/src/Booking.cpp
@@ -101,13 +101,14 @@ std::uint64_t bookingSuffixToken(
 } // namespace
 
 std::string bookingStatusToString(BookingStatus status) {
-    if (status == BookingStatus::CONFIRMED) {
+    using enum BookingStatus;
+    if (status == CONFIRMED) {
         return "Confirmed";
     }
-    if (status == BookingStatus::CANCELLED) {
+    if (status == CANCELLED) {
         return "Cancelled";
     }
-    if (status == BookingStatus::PENDING) {
+    if (status == PENDING) {
         return "Pending";
     }
     return "Unknown";

--- a/tests/api_server_routes_cases.inc
+++ b/tests/api_server_routes_cases.inc
@@ -164,14 +164,16 @@ TEST_F(ApiServerRoutesTest, SwapRoutesMapErrorsAndSuccess) {
     const auto same_booking_swap = swap_bookings_via_route(client, second_booking_id, second_booking_id);
     expect_response_status(same_booking_swap, 400);
 
-    [[maybe_unused]] const auto different_flights_swap = swap_bookings_via_route(client, second_booking_id, third_booking_id);
+    [[maybe_unused]] const auto different_flights_swap =
+        swap_bookings_via_route(client, second_booking_id, third_booking_id);
     expect_response_status(different_flights_swap, 400);
 
     Booking* refreshed_first_booking = createBooking(first_customer->getPersonId(), "FL101", "5C");
     ASSERT_NE(refreshed_first_booking, nullptr);
     const std::string refreshed_first_booking_id = refreshed_first_booking->getBookingId();
 
-    [[maybe_unused]] const auto successful_swap = swap_bookings_via_route(client, refreshed_first_booking_id, second_booking_id);
+    [[maybe_unused]] const auto successful_swap =
+        swap_bookings_via_route(client, refreshed_first_booking_id, second_booking_id);
     expect_response_status(successful_swap, 200);
     EXPECT_NE(
         json::parse(successful_swap->body).at("message").get<std::string>().find(


### PR DESCRIPTION
## **User description**
## Summary
Three Sonar findings surfaced on main after recent PRs:

| Rule | Where | Fix |
|---|---|---|
| `php:S103` (line length > 120) | `tests/api_server_routes_cases.inc:167,174` | Break two `[[maybe_unused]] const auto X = ...` lines at `=` |
| `cpp:S6177` (use `using enum`) | `src/Booking.cpp:103` | Restore `using enum BookingStatus;` so the if-else can reference enumerators by short name |

## Expected
- Sonar main open_issues: 3 → 0 after re-analysis.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Sonar line-length and enum-usage issues on main to clear all three open findings. Expected result: Sonar open issues drop from 3 to 0 after re-analysis.

- **Bug Fixes**
  - `tests/api_server_routes_cases.inc`: Split two long `[[maybe_unused]] const auto ... =` lines at `=` to meet `php:S103`.
  - `src/Booking.cpp`: Restore `using enum BookingStatus;` and use short enumerators to meet `cpp:S6177`.

<sup>Written for commit d93df4fed62c090ef400ecc66c0d39c18eea7270. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
Fix Sonar issues without changing booking behavior

### What Changed
- Booking status names are now written in a shorter form when converting them to text
- Two long test lines were split across multiple lines to keep them within the required length limit

### Impact
`✅ Fewer static analysis failures`
`✅ Cleaner booking status output`
`✅ No visible change to booking or swap behavior`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=5PqBbCNXlIJLrmp7AMQBMjqJQXDnDTBqwyE6bzqRYo0&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
