### PR TITLE
chore: promote cross-module security constants to public names

### DIFF
--- a/scripts/security_http_support.py
+++ b/scripts/security_http_support.py
@@ -11,8 +11,8 @@ from scripts.security_shared import (
     HTTPSRequestOptions,
     HTTPSRequestTarget,
     HTTPSResponsePayload,
-    _JSON_CONTENT_TYPE,
-    _SAFE_HEADER_NAME_CHARS,
+    JSON_CONTENT_TYPE,
+    SAFE_HEADER_NAME_CHARS,
 )
 from scripts.security_validation_support import (
     require_allowed_https_host,
@@ -69,7 +69,7 @@ def _contains_control_characters(value: str) -> bool:
 def _validate_header_name(name: str) -> str:
     """Validate a caller-provided HTTP header name."""
     checked = (name or "").strip()
-    if not checked or any(ch not in _SAFE_HEADER_NAME_CHARS for ch in checked):
+    if not checked or any(ch not in SAFE_HEADER_NAME_CHARS for ch in checked):
         raise ValueError(f"Invalid HTTP header name: {name!r}")
     return checked
 
@@ -91,7 +91,7 @@ def _merge_safe_headers(
     include_json_content_type: bool,
 ) -> Dict[str, str]:
     """Merge validated caller headers into the default JSON header set."""
-    final_headers: Dict[str, str] = {"Accept": _JSON_CONTENT_TYPE}
+    final_headers: Dict[str, str] = {"Accept": JSON_CONTENT_TYPE}
     if headers:
         for name, value in headers.items():
             checked_name = _validate_header_name(name)
@@ -100,7 +100,7 @@ def _merge_safe_headers(
                 name=checked_name,
             )
     if include_json_content_type:
-        final_headers.setdefault("Content-Type", _JSON_CONTENT_TYPE)
+        final_headers.setdefault("Content-Type", JSON_CONTENT_TYPE)
     return final_headers
 
 

--- a/scripts/security_shared.py
+++ b/scripts/security_shared.py
@@ -9,27 +9,27 @@ from typing import Any, Dict, FrozenSet, Optional, Set, Tuple
 
 Headers = Dict[str, str]
 
-_SAFE_REPO_SEGMENT_CHARS: FrozenSet[str] = frozenset(
+SAFE_REPO_SEGMENT_CHARS: FrozenSet[str] = frozenset(
     string.ascii_letters + string.digits + "._-"
 )
-_SAFE_SLUG_CHARS: FrozenSet[str] = frozenset(
+SAFE_SLUG_CHARS: FrozenSet[str] = frozenset(
     string.ascii_letters + string.digits + "._:-"
 )
-_SAFE_PATH_SEGMENT_CHARS: FrozenSet[str] = frozenset(
+SAFE_PATH_SEGMENT_CHARS: FrozenSet[str] = frozenset(
     string.ascii_letters + string.digits + "._-"
 )
-_SAFE_OUTPUT_NAME_CHARS: FrozenSet[str] = frozenset(
+SAFE_OUTPUT_NAME_CHARS: FrozenSet[str] = frozenset(
     string.ascii_letters + string.digits + "._-"
 )
-_HEX_CHARS: FrozenSet[str] = frozenset(string.hexdigits)
-_HOST_CHARS: FrozenSet[str] = frozenset(
+HEX_CHARS: FrozenSet[str] = frozenset(string.hexdigits)
+HOST_CHARS: FrozenSet[str] = frozenset(
     string.ascii_lowercase + string.digits + ".-"
 )
-_JSON_CONTENT_TYPE = "application/json"
-_SAFE_HEADER_NAME_CHARS: FrozenSet[str] = frozenset(
+JSON_CONTENT_TYPE = "application/json"
+SAFE_HEADER_NAME_CHARS: FrozenSet[str] = frozenset(
     string.ascii_letters + string.digits + "-"
 )
-_ALLOWED_HTTPS_HOSTS: FrozenSet[str] = frozenset(
+ALLOWED_HTTPS_HOSTS: FrozenSet[str] = frozenset(
     {
         "api.github.com",
         "api.codacy.com",
@@ -101,7 +101,7 @@ class HTTPSRequestOptions:
     allowed_hosts: Optional[Set[str]] = None
 
 
-_QUALITY_ARTIFACT_LAYOUT: Dict[QualityArtifact, Tuple[str, str, str]] = {
+QUALITY_ARTIFACT_LAYOUT: Dict[QualityArtifact, Tuple[str, str, str]] = {
     QualityArtifact.COVERAGE_100: ("coverage-100", "coverage.json", "coverage.md"),
     QualityArtifact.CODACY_ZERO: ("codacy-zero", "codacy.json", "codacy.md"),
     QualityArtifact.DEEPSCAN_ZERO: ("deepscan-zero", "deepscan.json", "deepscan.md"),

--- a/scripts/security_validation_support.py
+++ b/scripts/security_validation_support.py
@@ -12,14 +12,14 @@ from scripts.security_shared import (
     HTTPSRequestTarget,
     IdentifierRules,
     QualityArtifact,
-    _ALLOWED_HTTPS_HOSTS,
-    _HEX_CHARS,
-    _HOST_CHARS,
-    _QUALITY_ARTIFACT_LAYOUT,
-    _SAFE_OUTPUT_NAME_CHARS,
-    _SAFE_PATH_SEGMENT_CHARS,
-    _SAFE_REPO_SEGMENT_CHARS,
-    _SAFE_SLUG_CHARS,
+    ALLOWED_HTTPS_HOSTS,
+    HEX_CHARS,
+    HOST_CHARS,
+    QUALITY_ARTIFACT_LAYOUT,
+    SAFE_OUTPUT_NAME_CHARS,
+    SAFE_PATH_SEGMENT_CHARS,
+    SAFE_REPO_SEGMENT_CHARS,
+    SAFE_SLUG_CHARS,
 )
 
 
@@ -40,7 +40,7 @@ def require_identifier(raw: str, *, rules: IdentifierRules) -> str:
 
 def _has_invalid_host_characters(host: str) -> bool:
     """Return whether a hostname contains disallowed characters."""
-    return any(ch not in _HOST_CHARS for ch in host)
+    return any(ch not in HOST_CHARS for ch in host)
 
 
 def _has_empty_host_label(labels: List[str]) -> bool:
@@ -75,7 +75,7 @@ def _validate_output_filename(name: str, *, label: str) -> str:
         raise ValueError(f"Invalid {label}: {name!r}")
     if "/" in value or "\\" in value:
         raise ValueError(f"{label} must not contain path separators: {name!r}")
-    if any(ch not in _SAFE_OUTPUT_NAME_CHARS for ch in value):
+    if any(ch not in SAFE_OUTPUT_NAME_CHARS for ch in value):
         raise ValueError(f"Invalid {label}: {name!r}")
     return value
 
@@ -214,7 +214,7 @@ def require_allowed_https_host(
     """Validate an HTTPS host against the fixed or caller-supplied allowlist."""
     checked = _normalize_host(host)
     _reject_private_or_local_host(checked)
-    allowed = _ALLOWED_HTTPS_HOSTS if allowed_hosts is None else set(allowed_hosts)
+    allowed = ALLOWED_HTTPS_HOSTS if allowed_hosts is None else set(allowed_hosts)
     if checked not in _normalize_host_set(set(allowed)):
         raise ValueError(f"HTTPS host is not allowlisted: {host!r}")
     return checked
@@ -272,7 +272,7 @@ def require_repo_segment(raw: str, *, label: str) -> str:
         raw,
         rules=IdentifierRules(
             label=label,
-            allowed_chars=_SAFE_REPO_SEGMENT_CHARS,
+            allowed_chars=SAFE_REPO_SEGMENT_CHARS,
             min_len=1,
             max_len=100,
         ),
@@ -285,7 +285,7 @@ def require_slug(raw: str, *, label: str) -> str:
         raw,
         rules=IdentifierRules(
             label=label,
-            allowed_chars=_SAFE_SLUG_CHARS,
+            allowed_chars=SAFE_SLUG_CHARS,
             min_len=1,
             max_len=120,
         ),
@@ -295,7 +295,7 @@ def require_slug(raw: str, *, label: str) -> str:
 def require_sha(raw: str) -> str:
     """Validate a commit SHA using a bounded hexadecimal length."""
     value = (raw or "").strip()
-    if len(value) < 7 or len(value) > 40 or any(ch not in _HEX_CHARS for ch in value):
+    if len(value) < 7 or len(value) > 40 or any(ch not in HEX_CHARS for ch in value):
         raise ValueError(f"Invalid commit SHA: {raw!r}")
     return value
 
@@ -311,7 +311,7 @@ def quote_path_segment(value: str, *, label: str) -> str:
         value,
         rules=IdentifierRules(
             label=label,
-            allowed_chars=_SAFE_PATH_SEGMENT_CHARS,
+            allowed_chars=SAFE_PATH_SEGMENT_CHARS,
             min_len=1,
             max_len=120,
         ),
@@ -332,7 +332,7 @@ def fixed_output_paths(out_dir: str, json_name: str, md_name: str) -> Tuple[Path
 
 def quality_artifact_paths(artifact: QualityArtifact) -> Tuple[Path, Path]:
     """Return the JSON and markdown paths for a known quality artifact bundle."""
-    out_dir, json_name, md_name = _QUALITY_ARTIFACT_LAYOUT[artifact]
+    out_dir, json_name, md_name = QUALITY_ARTIFACT_LAYOUT[artifact]
     return fixed_output_paths(out_dir, json_name, md_name)
 
 


### PR DESCRIPTION
## **User description**
## Summary
CodeQL's `py/unused-global-variable` flags 10 leading-underscore globals in `scripts/security_shared.py` that are cross-module imports — they're actually used by sibling modules via `from scripts.security_shared import _X`, but CodeQL analyzes each module in isolation.

Drop the underscore prefix from the 10 genuinely shared names. Testing showed this is clean on DeepSource when done in isolation (the prior PR #42 that also renamed these was bundled with other metric-affecting changes).

## Expected
- CodeQL `py/unused-global-variable` count: 10 → 0.
- Codacy/Sonar/DeepSource unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Promoted shared security constants to public names and updated imports to stop CodeQL from flagging them as unused. Removes 10 `py/unused-global-variable` notes with no behavior change.

- **Refactors**
  - Renamed 10 private constants in `scripts/security_shared.py` to public: `SAFE_*_CHARS`, `HEX_CHARS`, `HOST_CHARS`, `JSON_CONTENT_TYPE`, `ALLOWED_HTTPS_HOSTS`, `QUALITY_ARTIFACT_LAYOUT`.
  - Updated references in `scripts/security_http_support.py` and `scripts/security_validation_support.py`.
  - CodeQL `py/unused-global-variable`: 10 → 0; Codacy/Sonar/DeepSource unchanged.

<sup>Written for commit 35cf89d839327534d8c8d7031b59900afc6ac01d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
Keep shared security checks working after renaming reused constants

### What Changed
- Renamed shared security values used across the security helper scripts so they can be imported normally from other modules
- Updated HTTPS header handling and validation logic to use the renamed shared values
- Kept the allowed host list, safe character sets, and artifact path layout used by the quality scripts unchanged

### Impact
`✅ Fewer false unused-code warnings`
`✅ Cleaner security script maintenance`
`✅ No change to security checks or script output`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=I7n0m-1W_RJIAG6QDGhfrSxSyFeRReA7Vgj-QjdPkO8&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
