### PR TITLE
fix(ci): bump QZP reusable-workflow SHAs to current main (per-flag Codecov upload)

### DIFF
--- a/.github/workflows/codecov-analytics.yml
+++ b/.github/workflows/codecov-analytics.yml
@@ -18,7 +18,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: Prekzursil/quality-zero-platform/.github/workflows/reusable-codecov-analytics.yml@d7a94db4ab57df42940832cf67b730c673af7da6
+    uses: Prekzursil/quality-zero-platform/.github/workflows/reusable-codecov-analytics.yml@4a909ca4491e34245bf40606e691c8979cb219d3
     with:
       repo_slug: ${{ github.repository }}
       event_name: ${{ github.event_name }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,7 +22,7 @@ jobs:
       actions: read
       contents: read
       security-events: write
-    uses: Prekzursil/quality-zero-platform/.github/workflows/reusable-codeql.yml@d7a94db4ab57df42940832cf67b730c673af7da6
+    uses: Prekzursil/quality-zero-platform/.github/workflows/reusable-codeql.yml@4a909ca4491e34245bf40606e691c8979cb219d3
     with:
       repo_slug: ${{ github.repository }}
       event_name: ${{ github.event_name }}

--- a/.github/workflows/quality-zero-backlog.yml
+++ b/.github/workflows/quality-zero-backlog.yml
@@ -12,7 +12,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: Prekzursil/quality-zero-platform/.github/workflows/reusable-backlog-sweep.yml@7268fee30f1cf796938d97fe460259f27386a8cd
+    uses: Prekzursil/quality-zero-platform/.github/workflows/reusable-backlog-sweep.yml@4a909ca4491e34245bf40606e691c8979cb219d3
     with:
       repo_slug: ${{ github.repository }}
       lane: quality

--- a/.github/workflows/quality-zero-gate.yml
+++ b/.github/workflows/quality-zero-gate.yml
@@ -16,7 +16,7 @@ jobs:
   aggregate-gate:
     permissions:
       contents: read
-    uses: Prekzursil/quality-zero-platform/.github/workflows/reusable-quality-zero-gate.yml@d7a94db4ab57df42940832cf67b730c673af7da6
+    uses: Prekzursil/quality-zero-platform/.github/workflows/reusable-quality-zero-gate.yml@4a909ca4491e34245bf40606e691c8979cb219d3
     with:
       repo_slug: ${{ github.repository }}
       event_name: ${{ github.event_name }}

--- a/.github/workflows/quality-zero-platform.yml
+++ b/.github/workflows/quality-zero-platform.yml
@@ -20,7 +20,7 @@ jobs:
       contents: read
       id-token: write
       pull-requests: write
-    uses: Prekzursil/quality-zero-platform/.github/workflows/reusable-scanner-matrix.yml@f73f84128d79a1160b766579abb690543b6bf6b7
+    uses: Prekzursil/quality-zero-platform/.github/workflows/reusable-scanner-matrix.yml@4a909ca4491e34245bf40606e691c8979cb219d3
     with:
       repo_slug: ${{ github.repository }}
       event_name: ${{ github.event_name }}

--- a/.github/workflows/quality-zero-remediation.yml
+++ b/.github/workflows/quality-zero-remediation.yml
@@ -14,7 +14,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: Prekzursil/quality-zero-platform/.github/workflows/reusable-remediation-loop.yml@7268fee30f1cf796938d97fe460259f27386a8cd
+    uses: Prekzursil/quality-zero-platform/.github/workflows/reusable-remediation-loop.yml@4a909ca4491e34245bf40606e691c8979cb219d3
     with:
       repo_slug: ${{ github.repository }}
       failure_context: Quality Zero Gate


### PR DESCRIPTION
## **User description**
## Summary

Airline pinned to pre-Phase-2 SHAs of QZP's reusable workflows, missing commit ``062e5c3`` (\"feat(qzp-v2 phase 2): Codecov per-flag upload + ingest validator\" — QZP PR #89). The old single-upload behaviour merged scripts/cpp/node under one Python-only blob, so although the local Coverage 100 Gate passes, Codecov shows ``cpp=0.0%`` and ``node=0.0%`` on every commit (44.49% combined).

Bumping every reusable-workflow pin to QZP main ``4a909ca4`` picks up the per-flag iteration that uploads each ``coverage.inputs[]`` entry under its own flag. Codecov should then show ``scripts``, ``node``, and ``cpp`` flags at their actual coverage percentages instead of 0.

## Verification
- [x] Local diff: only SHA bumps on 6 reusable-workflow ``uses:`` lines
- [ ] CI: Codecov Analytics passes with 3 distinct uploads (scripts, node, cpp) instead of 1
- [ ] Codecov UI: per-flag breakdown reflects actual coverage instead of 0%

<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Update all `Prekzursil/quality-zero-platform` reusable workflow pins to `4a909ca4` to enable Codecov per-flag uploads. This fixes `cpp` and `node` showing 0% by uploading `scripts`, `node`, and `cpp` separately.

- **Bug Fixes**
  - Per-flag Codecov upload restores accurate coverage for `cpp` and `node`.

- **Dependencies**
  - Bumped all `quality-zero-platform` reusable workflow references in six GitHub Actions files to `@4a909ca4`.

<sup>Written for commit 4b73b8e36bed2f912a9196a0343a2dd65e775a1c. Summary will update on new commits. <a href="https://cubic.dev/pr/Prekzursil/Airline-Reservations-System/pull/55?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Update shared workflow pins to restore per-flag Codecov reporting**

### What Changed
- All GitHub workflows now use the newer shared platform version that uploads coverage by flag instead of combining everything into one report
- Codecov analytics should now show separate coverage for scripts, Node, and C++ instead of leaving some flags at 0%
- The quality gate, backlog sweep, remediation, platform scan, Codecov analytics, and CodeQL workflows all follow the updated shared setup

### Impact
`✅ Accurate Codecov coverage for each language`
`✅ Fewer false 0% coverage readings`
`✅ Clearer CI coverage results`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=KCquethZHpngqYfEhljLwX2_NeyD7TWT-M2l-3W3BSQ&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
