### PR TITLE
fix(sonar): expand brace globs so .test.jsx is recognized as test, not source

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -12,7 +12,10 @@ sonar.sources=airline-gui/src,scripts
 sonar.tests=tests,airline-gui/src
 
 # Test inclusions: pytest tests under tests/ and vitest tests inside the React app.
-sonar.test.inclusions=**/test_*.py,**/*.test.{ts,tsx,js,jsx}
+# Brace expansion `{ts,tsx,js,jsx}` is NOT in Sonar's ant-style glob syntax
+# (PR #57 lift) — expand to comma-separated patterns so the matcher actually
+# fires on .test.jsx and friends.
+sonar.test.inclusions=**/test_*.py,**/*.test.ts,**/*.test.tsx,**/*.test.js,**/*.test.jsx
 
 # General exclusions: build/CMake outputs, vendored deps, generated coverage data,
 # vendored platform scripts (owned by Prekzursil/quality-zero-platform).
@@ -23,7 +26,7 @@ sonar.cpd.exclusions=**/build/**,**/_deps/**,**/CMakeFiles/**,scripts/quality/**
 # coverage gate in quality-zero-platform; excluding them here prevents
 # new_coverage from being dragged down for changes that don't touch them.
 # (Same pattern Prekzursil/event-link and Prekzursil/env-inspector use.)
-sonar.coverage.exclusions=scripts/__init__.py,scripts/quality/**,scripts/security_helpers.py,**/build/**,**/test_*.py,**/*.test.{ts,tsx,js,jsx},airline-gui/scripts/**
+sonar.coverage.exclusions=scripts/__init__.py,scripts/quality/**,scripts/security_helpers.py,**/build/**,**/test_*.py,**/*.test.ts,**/*.test.tsx,**/*.test.js,**/*.test.jsx,airline-gui/scripts/**
 
 sonar.python.version=3.12
 sonar.python.coverage.reportPaths=coverage/python/coverage.xml


### PR DESCRIPTION
## **User description**
Sonar's ant-style globber doesn't support brace expansion. Test files (.test.jsx, .test.tsx, etc.) were being indexed as sources with 0% coverage, dragging Sonar's reported line_coverage from real value down to 77.4%. Expanding the test.inclusions / coverage.exclusions patterns from `{ts,tsx,js,jsx}` to comma-separated should fix it on next reanalysis.

<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Replace brace expansion in Sonar test globs with explicit patterns so .test.ts/.tsx/.js/.jsx are recognized as tests and excluded from coverage. Restores accurate coverage on the next analysis.

- **Bug Fixes**
  - Updated `sonar.test.inclusions` and `sonar.coverage.exclusions` from `**/*.test.{ts,tsx,js,jsx}` to `**/*.test.ts,**/*.test.tsx,**/*.test.js,**/*.test.jsx`.
  - Reason: Sonar’s ant-style globs don’t support `{}` brace expansion, causing tests to be indexed as sources.

<sup>Written for commit a61acd0a02acf696fab616fa9c010c04989b4418. Summary will update on new commits. <a href="https://cubic.dev/pr/Prekzursil/Airline-Reservations-System/pull/57?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Sonar now recognizes React test files correctly**

### What Changed
- `.test.ts`, `.test.tsx`, `.test.js`, and `.test.jsx` files are now matched as tests instead of being treated as source code
- Those test files are also excluded from coverage totals, so they no longer lower the reported coverage score

### Impact
`✅ More accurate Sonar coverage`
`✅ Fewer test files counted as uncovered source`
`✅ Clearer quality reports`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=yiJm_hm3X-WOO_Z9dOzux3yT8DDHlBHc4qgYJ8LVmmA&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
