### PR TITLE
fix(deps): clear two dev-dep advisories that reddened main after #92

### DIFF
--- a/airline-gui/package-lock.json
+++ b/airline-gui/package-lock.json
@@ -1995,9 +1995,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2893,9 +2893,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
**main is currently red and I caused it.** It was green at `3b1c8fae` and red at `fcecfce0`; I merged both commits in that window.

Merging #92 (postcss) regenerated `airline-gui/package-lock.json` and pulled in two **transitive dev** dependencies carrying advisories:

| package | from | to | advisory | CVSS |
|---|---|---|---|---|
| `brace-expansion` (dev) | 5.0.8 | 5.0.9 | GHSA-rgw5-rvv9-x895 | 7.5 |
| `nanoid` (dev) | 3.3.16 | 3.3.18 | GHSA-2v37-7h3g-55p8 | 8.2 |

Neither is a direct dependency and both resolve inside their existing semver ranges, so `npm update nanoid brace-expansion --package-lock-only` is the entire fix — no `package.json` change, no override pin, and **no ignore entry**.

Verified with the same pinned scanner the gate runs (osv-scanner v2.3.8): findings went **2 → 0**.

## The mechanism is worth more than the two lines

**#92 was green when I merged it, and main was red minutes later.** Nothing about the tree changed between those states except which advisories existed. `gate-deps` reads a live feed, so its finding-set is not a function of the code — "green at merge" does not imply "green after merge", and no amount of care at review time prevents it.

Both findings here are **dev-only**, which is exactly the class the T0 severity floor demotes to inventory rather than blocking a product branch. That floor is merged on `quality-zero-platform` main but **not deployed** — every caller still pins `reusable-quality.yml@v1` and that tag has not moved — so the old all-or-nothing behaviour is what ran.

Fixing the deps is right regardless. But this is a live, unplanned demonstration of why the floor matters: a routine dependency bump reddened a product branch on two dev-only findings within minutes of a clean merge.